### PR TITLE
fix: Scribe game_time drift and PC-action bias (closes #3)

### DIFF
--- a/src/agent/gm_agent.py
+++ b/src/agent/gm_agent.py
@@ -836,6 +836,13 @@ def scribe_init_node(state: GMAgentState) -> dict[str, Any]:
     
     # 4. THIS TURN's content - extracted and formatted clearly
     this_turn_content = _extract_this_turn_content(messages, history_count)
+
+    # Append the GM's final narrative response so the scribe sees what actually happened.
+    # gm_final_response is captured by capture_gm_response_node and lives in state,
+    # not in the messages list, which is why _extract_this_turn_content misses it.
+    gm_final_response = state.get("gm_final_response", "")
+    if gm_final_response:
+        this_turn_content = this_turn_content + f"\n\nGM RESPONSE:\n{gm_final_response}"
     
     scribe_messages.append(SystemMessage(
         content=(

--- a/src/agent/prompts.py
+++ b/src/agent/prompts.py
@@ -337,18 +337,35 @@ You are responsible for tracking game time via the `game_time` field on events.
 - Game time is measured in SECONDS since the game began (Day 1, 00:00:00)
 - Time reference: 60 seconds = 1 minute, 3600 = 1 hour, 86400 = 1 day
 - The CURRENT GAME TIME will be provided to you - this is the highest time recorded so far
-- For each event, ADD estimated duration to the current time:
+- **FIRST: Check the GM response for explicit time references** ("two days of travel", "by morning", "an hour later", "the next day"). If found, calculate game_time from those. ONLY fall back to the estimates below if no time reference exists in the narrative.
+- For each event, ADD the duration to the current time:
   - Quick action/dialogue: +30 to +60 seconds
   - Brief conversation: +120 to +300 seconds (2-5 minutes)
   - Combat round: +6 seconds per round
   - Short rest: +3600 seconds (1 hour)
-  - Travel/exploration: +1800 to +7200 seconds (30 min to 2 hours)
+  - Travel/exploration (hours): +1800 to +7200 seconds (30 min to 2 hours)
+  - Overnight camp / long rest: +28800 seconds (8 hours)
+  - Full day of travel: +86400 seconds (1 day)
+  - Multi-day travel: +86400 per day mentioned
+  - Time skip ("the next morning", "weeks later"): calculate from the narrative
 
-**Example:** If current game time is 5460 seconds and a 30-second action happens:
-- First event: game_time = 5460 + 30 = 5490
-- Second event in same turn: game_time = 5490 + 6 = 5496
+**Example 1 (narrative time):** GM says "Two days of hard travel." Current game time = 5460.
+- game_time = 5460 + 172800 = 178260
+
+**Example 2 (estimated time):** GM describes a quick conversation, no time stated. Current game time = 5460.
+- game_time = 5460 + 120 = 5580
 
 NEVER set game_time lower than the current game time provided to you.
+
+## What to Record
+
+Record ALL significant events from the GM's response, not just player actions:
+- Player character actions and decisions
+- NPC actions that advance the plot (rituals, discoveries, betrayals, revelations, spiritual events)
+- Arrivals, departures, and location changes
+- Significant dialogue that establishes new world facts
+
+If the GM response contains multiple distinct events, call `record_event` multiple times — one call per significant beat. Do not collapse an NPC ritual and a PC decision into a single event.
 
 ## Event Format
 - `name`: Short title ("Tavern Arrival", "Combat: Goblin Attack")


### PR DESCRIPTION
## Summary

The scribe agent was recording inaccurate game time (a multi-day journey recorded as ~60 seconds) and completely omitting significant NPC-driven events (Isara's spiritual communion was not recorded at all). Both bugs share a single root cause: `scribe_init_node()` was never passing the GM's narrative response to the scribe. The scribe only saw the player's message, not what the GM narrated.

## Root Cause

`scribe_init_node()` built its THIS TURN context from `_extract_this_turn_content()`, which extracts only from the main `messages` list. The GM's narrative response lives in `state["gm_final_response"]` — captured separately by `capture_gm_response_node` — and was never injected into the scribe's context. The scribe was therefore unable to see multi-day travel descriptions or any NPC-driven plot events in the GM's response.

Additionally, the system prompt had gaps: time estimation maxed out at 2 hours with no guidance for multi-day events, and there was no instruction to record NPC-driven narrative events.

## Changes

- `src/agent/gm_agent.py` — `scribe_init_node()`: inject `gm_final_response` from state into the scribe's THIS TURN context block so the scribe sees the full GM narrative each turn
- `src/agent/prompts.py` — `SCRIBE_SYSTEM_PROMPT`: add a narrative-grounded time estimation rule (check GM text for explicit durations before estimating), expand duration categories to cover overnight/multi-day/time-skip events, and add a "What to Record" section requiring NPC-driven plot events to be captured alongside PC actions

## How to Test

1. Start a game session with active travel
2. Have the GM narrate a multi-day journey (e.g. "Two days of hard travel bring you to Whitefang Pass")
3. Expected: scribe records `game_time` += ~172800 (2 days), not += 60
4. Have the GM narrate an NPC performing a significant action (ritual, revelation, betrayal)
5. Expected: scribe records a separate event for the NPC action, not only the PC decision

## Linked Issue

Closes #3

## Linked Bug Reports

- `bug_reports._id=6999fe5a09eacf4502486581` (game_time drift) — `triages._id=699a1f533ccc83efdd8ee39e`
- `bug_reports._id=6999fdd009eacf4502486580` (PC-action bias) — `triages._id=699a1f533ccc83efdd8ee39f`