### PR TITLE
fix: Historian reactive search misses incidentally referenced NPCs (closes #2)

### DIFF
--- a/src/agent/gm_agent.py
+++ b/src/agent/gm_agent.py
@@ -654,7 +654,16 @@ def historian_init_node(state: GMAgentState) -> dict[str, Any]:
         historian_messages.append(SystemMessage(content=f"[WORLD STATE]\n{world_context}\n[END WORLD STATE]"))
     if events_context:
         historian_messages.append(SystemMessage(content=f"[RECENT EVENTS]\n{events_context}\n[END RECENT EVENTS]"))
-    
+
+    # Inject the prior GM response so the historian can proactively look up NPCs
+    # the GM is likely to re-narrate this turn, not just those the player mentioned
+    if history_count > 0:
+        prior_msg = messages[history_count - 1]
+        if isinstance(prior_msg, AIMessage) and prior_msg.content:
+            historian_messages.append(SystemMessage(
+                content=f"[PRIOR GM RESPONSE]\n{prior_msg.content}\n[END PRIOR GM RESPONSE]"
+            ))
+
     # Current turn user message
     if history_count < len(messages):
         player_msg = messages[history_count]

--- a/src/agent/prompts.py
+++ b/src/agent/prompts.py
@@ -9,13 +9,15 @@ HISTORIAN_SYSTEM_PROMPT = """You are a HISTORIAN - a research assistant for a ta
 Your job is to enrich the GM's context by finding relevant information.
 
 ## Process
-1. Analyze the WORLD STATE, RECENT EVENTS, and PLAYER MESSAGE
+1. Analyze the WORLD STATE, RECENT EVENTS, PLAYER MESSAGE, and PRIOR GM RESPONSE (if provided)
 2. Identify any people, places, things, or events referenced that lack detail
 3. Use search tools to find additional relevant information
-4. Return what you found as structured context
+4. If faction or location results name specific characters (leaders, shamans, key figures), look those characters up via find_characters — but only one hop deeper; do not chain further lookups from those follow-up results
+5. Return what you found as structured context
 
 ## What to Look For
 - Characters mentioned by name (use find_characters to search if not in player_characters)
+- Named NPCs from the PRIOR GM RESPONSE who may appear again this turn — look them up even if the player did not mention them
 - Locations referenced that need more detail
 - Historical events or lore that might be relevant
 - Past chronicles that relate to current situation


### PR DESCRIPTION
## Summary

The historian was purely reactive — it only searched based on what the player said, so NPCs introduced or re-introduced by the GM without a player mention (e.g., Shaman Torva) had no path into context. The GM then narrated those NPCs with no description available, defaulting to hallucinated details (wrong gender for Torva). Two targeted changes fix this: the historian now receives the prior GM response as context and is instructed to proactively look up named NPCs from it, and it also follows up on named characters surfaced by faction/location results — bounded to one hop to prevent runaway reference chains.

## Root Cause

The historian is reactive: it searches based on the current player message only. NPCs appearing incidentally — not mentioned by the player but re-narrated by the GM — have no guaranteed path into the GM's context window.

## Changes

- `src/agent/prompts.py` — Updated `HISTORIAN_SYSTEM_PROMPT`: added "PRIOR GM RESPONSE (if provided)" to the analysis inputs in Process step 1; added a new step 4 instructing the historian to look up named characters from faction/location results (one hop only, no further chaining); added a "What to Look For" bullet for named NPCs from the prior GM response
- `src/agent/gm_agent.py` — In `historian_init_node`, inject the last `AIMessage` from conversation history as a `[PRIOR GM RESPONSE]` system message, inserted after RECENT EVENTS and before PLAYER MESSAGE

## How to Test

1. Start a game session with an established NPC (e.g., a shaman with a known gender/description in the `characters` collection)
2. Have the GM narrate that NPC in one turn
3. On the next turn, send a player message that does **not** mention the NPC by name (e.g., "We must bring this to the elders")
4. Check the historian's tool calls in the trace — it should call `find_characters` for the NPC named in the prior GM response
5. Expected: the GM's response in the new turn uses the correct pronouns/description for the NPC

## Linked Issue

Closes #2

## Linked Bug Reports

- `bug_reports._id=6999feda09eacf4502486582`
- `triages._id=699a1dfa5fda06e5ca1557c1`