### PR TITLE
fix: Add Barrister node — game mechanics enrichment for GM pipeline (closes #9)

### DIFF
--- a/src/api/messages.py
+++ b/src/api/messages.py
@@ -310,7 +310,7 @@ async def process_message_background(
                 try:
                     state = agent_result.final_state
                     agent_message_keys = [
-                        "historian_messages", "gm_messages", "bard_messages",
+                        "historian_messages", "barrister_messages", "gm_messages", "bard_messages",
                         "accountant_messages", "scribe_messages",
                         "world_creator_messages", "char_creator_messages",
                     ]


### PR DESCRIPTION
## Summary

When a player declared a skill check (e.g. "Insight check"), the GM narrated a fully successful outcome without rolling dice — treating it as narrative flavor rather than a mechanical trigger. This PR fixes the bug with two complementary changes: a new **Barrister** subagent that computes a mechanics brief before the GM runs, and an explicit **check-resolution rule** in the GM prompt requiring `roll_dice` be called before narrating any declared check outcome.

## Root Cause

Two compounding gaps:
1. `GM_SYSTEM_PROMPT` said "if a roll is needed, call `roll_dice`" but gave no rule for when a player *explicitly declares* a check. The GM treated "Insight check" as narrative cue, not a mechanical trigger.
2. No pipeline node enriched mechanics context before the GM ran — no one told the GM what ability governs the check, what DC to use, what modifiers apply, or what different result tiers should reveal.

## Changes

- `src/agent/prompts.py` — Added `BARRISTER_SYSTEM_PROMPT`: a system-agnostic prompt that surveys the full turn situation (player action, NPC actions, environmental effects, ongoing conditions, active modifiers) and produces a mechanics brief for the GM. Updated `GM_SYSTEM_PROMPT` with: (1) a 4th bullet in "Context Is Pre-Loaded" listing the MECHANICS BRIEF, (2) a new "Skill Checks and Ability Rolls" section with explicit `roll_dice` trigger rule, (3) updated "During Play" step 3 to reference [MECHANICS BRIEF].
- `src/agent/gm_agent.py` — Added `barrister_messages` and `mechanics_context` to `GMAgentState`. Added `create_barrister_agent_node()` (plain LLM, no tools in v1), `compile_barrister_context_node()`, and `barrister_init_node()`. Updated `gm_init_node()` to inject `mechanics_context` as `[MECHANICS BRIEF]`. Wired the graph: `compile_historian → barrister_init → barrister → compile_barrister → gm_init`. Instantiated `barrister_llm` at temperature 0.3.
- `src/api/messages.py` — Added `"barrister_messages"` to the trace key list so the Barrister's conversation is persisted under `agent_messages.barrister` in every trace, consistent with all other agents.

## How to Test

1. Start a D&D 5e game session with a character who has a non-trivial WIS modifier
2. Submit a player message declaring an explicit skill check: `"Insight check"` or `"I try to pick the lock"`
3. Expected: GM calls `roll_dice` (visible in tool calls) before narrating the outcome
4. Expected: GM narration varies based on the roll result — a low roll yields surface impressions only; a high roll yields deeper detail
5. In the trace (`agent_messages.barrister`), verify the Barrister produced a brief naming the relevant ability, DC, and outcome tiers
6. For a purely narrative beat (e.g. "I sit down at the tavern"), verify the Barrister returns an empty brief and the GM narrates without rolling

## Linked Issue

Closes #9

## Linked Bug Reports

- `bug_reports._id=699a8220a691929278aa3675`
- `triages._id=699b46150fc5e81b42fe6568`
