### PR TITLE
fix: Accountant entity ID resolution via historian tool result map (closes #22)

### DIFF
--- a/src/agent/nodes/accountant.py
+++ b/src/agent/nodes/accountant.py
@@ -1,5 +1,6 @@
 """Accountant sub-agent — syncs game state changes (damage, healing, status, items) to the DB."""
 
+import json
 import logging
 from typing import Any, Literal
 
@@ -8,6 +9,7 @@ from langgraph.graph import END
 
 from ..prompts import ACCOUNTANT_SYSTEM_PROMPT
 from ..state import GMAgentState
+from .utils import extract_entity_ids
 
 logger = logging.getLogger(__name__)
 
@@ -43,6 +45,33 @@ def accountant_init_node(state: GMAgentState) -> dict[str, Any]:
     if world_context:
         accountant_messages.append(SystemMessage(
             content=f"=== WORLD STATE (use these IDs for tool calls) ===\n\n{world_context}"
+        ))
+
+    # Build a unified name→id map from world_context (deterministic) and the
+    # historian-derived map (dynamic). World context is the base; historian
+    # results overlay it so any freshly-fetched IDs take precedence.
+    combined_entity_map: dict[str, str] = {}
+    if world_context:
+        try:
+            combined_entity_map.update(extract_entity_ids(json.loads(world_context)))
+        except (json.JSONDecodeError, TypeError, ValueError):
+            pass
+
+    historian_entity_map = state.get("entity_id_map")
+    if historian_entity_map:
+        try:
+            combined_entity_map.update(json.loads(historian_entity_map))
+        except (json.JSONDecodeError, TypeError, ValueError):
+            pass
+
+    if combined_entity_map:
+        accountant_messages.append(SystemMessage(
+            content=(
+                "=== ENTITY ID MAP (name → database ID) ===\n\n"
+                f"{json.dumps(combined_entity_map)}\n\n"
+                "Use these IDs when a tool parameter requires an entity ID and "
+                "the exact ID is not already present in the WORLD STATE above."
+            )
         ))
 
     if gm_response:

--- a/src/agent/nodes/historian.py
+++ b/src/agent/nodes/historian.py
@@ -1,5 +1,6 @@
 """Historian sub-agent — read-only context enrichment via search tools."""
 
+import json
 import logging
 from typing import Any, Literal
 
@@ -7,6 +8,7 @@ from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, Tool
 
 from ..prompts import HISTORIAN_SYSTEM_PROMPT
 from ..state import GMAgentState
+from .utils import extract_entity_ids
 
 logger = logging.getLogger(__name__)
 
@@ -92,9 +94,17 @@ def create_historian_agent_node(llm_with_historian_tools, db):
 
 
 def compile_historian_context_node(state: GMAgentState) -> dict[str, Any]:
-    """Capture historian output (and tool results) into enriched_context for the GM."""
+    """Capture historian output (and tool results) into enriched_context for the GM.
+
+    Also builds entity_id_map by deterministically parsing all ToolMessage JSON
+    responses to extract name→id pairs for every entity the historian fetched.
+    This map is injected into the accountant's context so it can resolve entity
+    names to database IDs without needing its own lookup tools.
+    """
     messages = state.get("historian_messages", [])
     parts = []
+    entity_map: dict[str, str] = {}
+
     for msg in messages:
         if isinstance(msg, AIMessage):
             content = getattr(msg, "content", None)
@@ -106,12 +116,25 @@ def compile_historian_context_node(state: GMAgentState) -> dict[str, Any]:
             content = getattr(msg, "content", None) or str(msg)
             if isinstance(content, list):
                 content = str(content)
+
+            # Deterministically extract entity IDs from the raw tool result before truncation
+            try:
+                parsed = json.loads(content if isinstance(content, str) else str(content))
+                entity_map.update(extract_entity_ids(parsed))
+            except (json.JSONDecodeError, TypeError, ValueError):
+                pass  # Tool result wasn't JSON (e.g. plain-text error message)
+
             if len(str(content)) > 2000:
                 content = str(content)[:2000] + "..."
             parts.append(f"{getattr(msg, 'name', 'tool')}: {content}")
+
     enriched_context = "\n\n".join(parts) if parts else "{}"
-    logger.debug(f"[compile_historian] enriched_context len={len(enriched_context)}, parts={len(parts)}")
-    return {"enriched_context": enriched_context}
+    entity_id_map = json.dumps(entity_map)
+    logger.debug(
+        f"[compile_historian] enriched_context len={len(enriched_context)}, "
+        f"parts={len(parts)}, entity_id_map entries={len(entity_map)}"
+    )
+    return {"enriched_context": enriched_context, "entity_id_map": entity_id_map}
 
 
 def should_continue_historian(state: GMAgentState) -> Literal["historian_tools", "compile_historian"]:

--- a/src/agent/nodes/utils.py
+++ b/src/agent/nodes/utils.py
@@ -1,0 +1,23 @@
+"""Shared utilities for agent nodes."""
+
+from typing import Any
+
+
+def extract_entity_ids(data: Any) -> dict[str, str]:
+    """Recursively extract name→id pairs from any JSON structure.
+
+    Handles both list responses (find_* tools) and single-object responses.
+    Accepts both 'id' and '_id' field names since MongoDB serialization isn't consistent.
+    """
+    result: dict[str, str] = {}
+    if isinstance(data, dict):
+        name = data.get("name")
+        entity_id = data.get("id") or data.get("_id")
+        if name and entity_id:
+            result[str(name)] = str(entity_id)
+        for value in data.values():
+            result.update(extract_entity_ids(value))
+    elif isinstance(data, list):
+        for item in data:
+            result.update(extract_entity_ids(item))
+    return result

--- a/src/agent/state.py
+++ b/src/agent/state.py
@@ -43,6 +43,10 @@ class GMAgentState(TypedDict, total=False):
     last_event_id: str   # Last event ID since last chronicle (for linking)
     current_game_time: int  # Game time in seconds from last event (for scribe to track time)
 
+    # Entity ID map built from historian tool results (name → id for any fetched entity)
+    # Injected into accountant context so it can resolve names to IDs without lookup tools
+    entity_id_map: str  # JSON string: {"Whitefang Pass": "abc123", ...}
+
     # GM's final response (captured before scribe runs)
     # This is what gets persisted to the database
     gm_final_response: str

--- a/src/api/messages.py
+++ b/src/api/messages.py
@@ -415,6 +415,7 @@ async def process_message_background(
                         route=route,
                         gm_final_response=gm_response,
                         agent_messages=agent_messages_serialized,
+                        entity_id_map=state.get("entity_id_map"),
                     )
                     trace_result = await db.traces.insert_one(trace.to_doc())
                     trace_id = str(trace_result.inserted_id)

--- a/src/models/trace.py
+++ b/src/models/trace.py
@@ -62,6 +62,7 @@ class Trace(BaseModel):
     route: str  # "gm" | "world_creator" | "char_creator"
     gm_final_response: str
     agent_messages: dict[str, list[dict]]  # agent name -> serialized messages
+    entity_id_map: Optional[str] = None  # JSON string: name→id map built from historian tool results + world context
     bug_report_ids: list[str] = Field(default_factory=list)
 
     def to_doc(self) -> dict:
@@ -101,5 +102,6 @@ class Trace(BaseModel):
             "route": self.route,
             "gm_final_response": self.gm_final_response,
             "agent_messages": self.agent_messages,
+            "entity_id_map": self.entity_id_map,
             "bug_report_ids": self.bug_report_ids,
         }


### PR DESCRIPTION
## Summary

The Accountant was stalling and silently dropping all identified state changes whenever the GM's narrative referenced an entity (location, NPC, item) by name that it couldn't resolve to a database ID. This PR gives the Accountant a deterministic name→id map built from two sources: (1) the world context already loaded at session start, and (2) every entity the Historian fetched during its tool calls — without touching the Historian's LLM prompt or tool loop.

## Root Cause

The Accountant has write-only tools and no lookup capability, so when a tool parameter required a 24-char hex ID (e.g. `location_id` for `move_character`) and the entity was only known by name in the GM narrative, the LLM had nowhere to resolve it. It would either hallucinate an ID, ask a clarification question (stalling), or skip the operation entirely.

## Changes

- `src/agent/nodes/utils.py` — new shared helper `extract_entity_ids(data)` that recursively walks any JSON structure and pulls out every `{name: id}` pair, accepting both `id` and `_id` field names
- `src/agent/nodes/historian.py` — in `compile_historian_context_node`, after building `enriched_context` (untouched), parse every `ToolMessage` JSON response with `extract_entity_ids` and emit the collected pairs as a new `entity_id_map` state field
- `src/agent/state.py` — add `entity_id_map: str` field to `GMAgentState`
- `src/agent/nodes/accountant.py` — in `accountant_init_node`, parse world context with `extract_entity_ids` (base layer) then overlay the historian-derived `entity_id_map` (dynamic layer); inject the combined map as a system message between the world state block and the GM narrative block
- `src/models/trace.py` — add `entity_id_map: Optional[str]` field so the map is persisted on each trace for debugging
- `src/api/messages.py` — pass `entity_id_map` from final state when constructing the `Trace`

## How to Test

1. Start a game session in a world that has named locations in the database
2. Move a player character to a named location via the GM narrative (e.g. "Keth moves toward Whitefang Pass")
3. Check the trace in MongoDB — `entity_id_map` should contain `{"Whitefang Pass": "<id>"}` if the Historian ran `find_locations` or `search_locations` this turn
4. Check `accountant_messages` in the trace — the system message `=== ENTITY ID MAP ===` should appear with the resolved IDs
5. Confirm `move_character` was called with the correct `location_id` rather than being skipped

## Linked Issue

Closes #22
