### PR TITLE
fix: GM proactive random event mechanic to prevent monotonous sessions (closes #18)

### DIFF
--- a/src/agent/nodes/gm.py
+++ b/src/agent/nodes/gm.py
@@ -1,14 +1,26 @@
 """GM sub-agent — main narration, dice, and combat management."""
 
 import logging
+import random
 from typing import Any, Literal
 
 from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, SystemMessage
 
-from ..prompts import GM_SYSTEM_PROMPT
+from ..prompts import (
+    GM_RANDOM_EVENT_BOON,
+    GM_RANDOM_EVENT_CONFLICT,
+    GM_RANDOM_EVENT_PLEASANT,
+    GM_SYSTEM_PROMPT,
+)
 from ..state import GMAgentState
 
 logger = logging.getLogger(__name__)
+
+_RANDOM_EVENT_PROMPTS = {
+    1:  GM_RANDOM_EVENT_CONFLICT,
+    19: GM_RANDOM_EVENT_PLEASANT,
+    20: GM_RANDOM_EVENT_BOON,
+}
 
 GM_TOOL_NAMES = {
     "roll_dice", "roll_table", "coin_flip", "roll_stat_array", "percentile_roll",
@@ -98,6 +110,13 @@ def gm_init_node(state: GMAgentState) -> dict[str, Any]:
         system_messages.append(SystemMessage(
             content=f"[WORLD ID]\nworld_id for all tool calls: {world_id}\n[END WORLD ID]"
         ))
+
+    roll = random.randint(1, 20)
+    logger.info(f"[gm_init] Proactive event roll: {roll}")
+    event_prompt = _RANDOM_EVENT_PROMPTS.get(roll)
+    if event_prompt:
+        system_messages.append(SystemMessage(content=event_prompt))
+        logger.info(f"[gm_init] Injecting proactive event prompt for roll {roll}")
 
     gm_messages = system_messages + messages
     logger.debug(

--- a/src/agent/prompts.py
+++ b/src/agent/prompts.py
@@ -380,6 +380,20 @@ Now create adventures!"""
 
 
 # ============================================================================
+# GM Proactive Random Event Prompts
+# ============================================================================
+
+GM_RANDOM_EVENT_CONFLICT = """[PROACTIVE EVENT — OMEN OF CONFLICT]
+Somewhere in your response this turn, weave in a subtle environmental hint that something dangerous or troubling may be approaching — independently of what the player said or did. Do not resolve the threat yet; just plant the seed. Examples: a distant rumble of thunder that feels wrong, the smell of smoke on the wind, an unnatural silence where birds should be calling, a shadow moving at the edge of vision, a horse that suddenly refuses to move. The hint should feel organic to the current setting and tone. Do not announce that a "random event" has occurred and do not break the flow of the scene."""
+
+GM_RANDOM_EVENT_PLEASANT = """[PROACTIVE EVENT — HINT OF GOOD FORTUNE]
+Somewhere in your response this turn, weave in a small unexpected detail that suggests something pleasant or lucky may be near — independently of what the player said or did. Do not resolve it yet; just let it linger. Examples: a glint of something shiny half-buried in the dirt, a stranger's warm smile and a nod of recognition, an unusually beautiful wildflower growing alone in a harsh place, a coin found on the path. Keep it subtle and proportional to the scene. Do not announce that a "random event" has occurred and do not break the flow of the scene."""
+
+GM_RANDOM_EVENT_BOON = """[PROACTIVE EVENT — HINT OF DISCOVERY]
+Somewhere in your response this turn, weave in a subtle detail that suggests a meaningful discovery or reward may be within reach — independently of what the player said or did. Do not hand it to the player yet; just make it visible. Examples: an unusual carving on a rock face, a faint trail of footprints leading off the path, a structure barely visible through the trees, a fragment of an old map sticking out of the mud. The detail should feel organic to the setting. Do not announce that a "random event" has occurred and do not break the flow of the scene."""
+
+
+# ============================================================================
 # Scribe Agent Prompt
 # ============================================================================
 


### PR DESCRIPTION
## Summary

The GM pipeline was entirely reactive — it only responded to player input, making extended travel and quiet scenes feel monotonous. This PR adds a proactive random event mechanic: at the start of every GM turn, `gm_init_node` rolls a d20 (`random.randint(1, 20)`) and, on a 1, 19, or 20, injects a final `SystemMessage` directing the GM to weave a subtle narrative seed into its response. The seeds are intentionally low-key (an ominous smell, a glint in the bushes, a strange carving) so the GM plants a hook rather than forcing an immediate resolution, giving the story room to breathe and pick up the thread in later turns.

## Root Cause

No proactive event system was ever designed — the entire pipeline (historian → GM → scribe) was built as a request-response loop with no scheduled or probabilistic event generation step. The GM prompt had no instruction to consider injecting surprise events independently of player input.

## Changes

- `src/agent/prompts.py` — added three new prompt constants (`GM_RANDOM_EVENT_CONFLICT`, `GM_RANDOM_EVENT_PLEASANT`, `GM_RANDOM_EVENT_BOON`) that instruct the GM to plant a subtle environmental seed without breaking scene flow or announcing a random event
- `src/agent/nodes/gm.py` — added `import random`, a module-level `_RANDOM_EVENT_PROMPTS` dict mapping roll values to prompts, and a roll/inject block at the end of `gm_init_node` (after all other system messages, so it is the final instruction before the conversation history)

## How to Test

1. Start a session in a quiet, low-stakes scene (travel, camp, downtime)
2. Submit a neutral player action (e.g. "Kael tends to the horses")
3. Check the server logs for `[gm_init] Proactive event roll: <N>` — on a 1, 19, or 20 you should also see `Injecting proactive event prompt for roll <N>`
4. On a triggering roll, verify the GM response includes a subtle environmental detail (an ominous sound, a small lucky find, or an intriguing discovery) woven naturally into the narration without explicitly announcing a random event
5. On a non-triggering roll (2–18), verify the GM response is a normal reactive turn with no injected detail

## Linked Issue

Closes #18

## Linked Bug Reports

- `bug_reports._id=699d44f0987ab34c872d0155`
- `triages._id=699dc42fa8f570482020fb3c`