### PR TITLE
fix: Scribe dice rolls (notation, result, DC, pass/fail) not recorded in events log (closes #26)

### DIFF
--- a/src/agent/nodes/accountant.py
+++ b/src/agent/nodes/accountant.py
@@ -9,7 +9,7 @@ from langgraph.graph import END
 
 from ..prompts import ACCOUNTANT_SYSTEM_PROMPT
 from ..state import GMAgentState
-from .utils import extract_entity_ids
+from .utils import extract_entity_ids, extract_gm_tool_calls
 
 logger = logging.getLogger(__name__)
 
@@ -31,7 +31,7 @@ def accountant_init_node(state: GMAgentState) -> dict[str, Any]:
     world_id = state.get("world_id")
     world_context = state.get("world_context")
     gm_response = state.get("gm_final_response", "")
-    gm_tool_calls = state.get("gm_tool_calls", [])
+    gm_tool_calls = extract_gm_tool_calls(state.get("gm_messages", []))
 
     logger.debug("[accountant_init] Building context for Accountant")
 

--- a/src/agent/nodes/gm.py
+++ b/src/agent/nodes/gm.py
@@ -151,11 +151,10 @@ def create_gm_agent_node(llm_with_tools, db):
 
 
 def capture_gm_response_node(state: GMAgentState) -> dict[str, Any]:
-    """Capture the GM's final response and tool calls before transitioning to post-processing agents.
+    """Capture the GM's final response before transitioning to post-processing agents.
 
-    This ensures we have:
-    1. The GM's response stored separately from subsequent agent messages
-    2. A record of all tool calls the GM made (for Accountant to avoid duplicates)
+    Extracts gm_final_response for early UI broadcast. Tool call data remains
+    in gm_messages and is read directly by the accountant and scribe init nodes.
     """
     messages = state.get("gm_messages", [])
 
@@ -166,29 +165,14 @@ def capture_gm_response_node(state: GMAgentState) -> dict[str, Any]:
                 gm_response = msg.content
                 break
 
-    gm_tool_calls = []
-    for msg in messages:
-        if isinstance(msg, AIMessage) and hasattr(msg, "tool_calls") and msg.tool_calls:
-            for tc in msg.tool_calls:
-                gm_tool_calls.append({
-                    "name": tc.get("name"),
-                    "args": tc.get("args", {})
-                })
-
     if gm_response:
         logger.info(f"[Capture] Captured GM response: {gm_response[:100]}...")
         logger.debug(f"[capture_response] gm_final_response len={len(gm_response)}")
     else:
         logger.warning("[Capture] No GM response found to capture")
 
-    if gm_tool_calls:
-        tool_names = [tc["name"] for tc in gm_tool_calls]
-        logger.info(f"[Capture] GM made {len(gm_tool_calls)} tool calls: {tool_names}")
-        logger.debug(f"[capture_response] gm_tool_calls: {tool_names}")
-
     return {
         "gm_final_response": gm_response,
-        "gm_tool_calls": gm_tool_calls,
     }
 
 

--- a/src/agent/nodes/scribe.py
+++ b/src/agent/nodes/scribe.py
@@ -10,6 +10,7 @@ from langgraph.graph import END
 from ..prompts import SCRIBE_SYSTEM_PROMPT
 from ..state import GMAgentState
 from .gm import _extract_this_turn_content
+from .utils import extract_gm_roll_results
 
 logger = logging.getLogger(__name__)
 
@@ -61,6 +62,17 @@ def scribe_init_node(state: GMAgentState) -> dict[str, Any]:
             f"{this_turn_content}"
         )
     ))
+
+    gm_roll_results = extract_gm_roll_results(state.get("gm_messages", []))
+    if gm_roll_results:
+        lines = [
+            f"- roll_dice: {r['notation']} = {r['total']} ({r['details']}) — {r['reason']}"
+            for r in gm_roll_results
+        ]
+        scribe_messages.append(SystemMessage(
+            content="=== MECHANICS THIS TURN ===\n" + "\n".join(lines)
+        ))
+        logger.debug(f"[scribe_init] injected {len(gm_roll_results)} roll result(s) into mechanics block")
 
     event_count = len(json.loads(events_context)) if events_context else 0
     logger.debug(f"[scribe_init] current_game_time={current_game_time}, event_count={event_count}")

--- a/src/agent/nodes/utils.py
+++ b/src/agent/nodes/utils.py
@@ -1,6 +1,9 @@
 """Shared utilities for agent nodes."""
 
+import json
 from typing import Any
+
+from langchain_core.messages import AIMessage, ToolMessage
 
 
 def extract_entity_ids(data: Any) -> dict[str, str]:
@@ -21,3 +24,48 @@ def extract_entity_ids(data: Any) -> dict[str, str]:
         for item in data:
             result.update(extract_entity_ids(item))
     return result
+
+
+def extract_gm_tool_calls(messages: list) -> list[dict]:
+    """Extract all tool call name+args made by the GM from gm_messages.
+
+    Used by the accountant to build its 'TOOLS GM ALREADY CALLED' block.
+    """
+    tool_calls = []
+    for msg in messages:
+        if isinstance(msg, AIMessage) and getattr(msg, "tool_calls", None):
+            for tc in msg.tool_calls:
+                tool_calls.append({"name": tc.get("name"), "args": tc.get("args", {})})
+    return tool_calls
+
+
+def extract_gm_roll_results(messages: list) -> list[dict]:
+    """Extract roll_dice call+result pairs from gm_messages.
+
+    Used by the scribe to build its MECHANICS THIS TURN block.
+    Each returned dict: {notation, reason, total, details}
+    """
+    tool_results: dict[str, str] = {}
+    for msg in messages:
+        if isinstance(msg, ToolMessage):
+            tid = getattr(msg, "tool_call_id", None)
+            if tid:
+                tool_results[tid] = msg.content
+
+    rolls = []
+    for msg in messages:
+        if isinstance(msg, AIMessage) and getattr(msg, "tool_calls", None):
+            for tc in msg.tool_calls:
+                if tc.get("name") == "roll_dice":
+                    raw = tool_results.get(tc.get("id", ""), "")
+                    try:
+                        parsed = json.loads(raw)
+                    except Exception:
+                        parsed = {}
+                    rolls.append({
+                        "notation": tc["args"].get("notation", ""),
+                        "reason":   tc["args"].get("reason", ""),
+                        "total":    parsed.get("total", "?"),
+                        "details":  parsed.get("details", raw[:120]),
+                    })
+    return rolls

--- a/src/agent/prompts.py
+++ b/src/agent/prompts.py
@@ -444,6 +444,16 @@ Record ALL significant events from the GM's response, not just player actions:
 
 If the GM response contains multiple distinct events, call `record_event` multiple times — one call per significant beat. Do not collapse an NPC ritual and a PC decision into a single event.
 
+## Mechanics Recording
+
+If a `=== MECHANICS THIS TURN ===` block appears in your context, the GM made
+dice rolls this turn. For each event that involved a roll, include the mechanical
+outcome inline in the event `description`:
+  [Roll: 1d20+3 = 6 (Perception check — cursory survey)]
+
+Attach each roll to the event it most directly influenced. If a roll's purpose
+does not match a specific event, append it to the most relevant event's description.
+
 ## Event Format
 - `name`: Short title ("Tavern Arrival", "Combat: Goblin Attack")
 - `description`: What happened (1-2 sentences)

--- a/src/agent/state.py
+++ b/src/agent/state.py
@@ -51,10 +51,6 @@ class GMAgentState(TypedDict, total=False):
     # This is what gets persisted to the database
     gm_final_response: str
 
-    # GM's tool calls (captured for Accountant to avoid duplicates)
-    # Contains list of tool call dicts with 'name' and 'args'
-    gm_tool_calls: list[dict]
-
     # World creation phase: when True, route to world_creator agent
     creation_in_progress: bool
 


### PR DESCRIPTION
## Summary

Dice rolls the GM makes each turn were silently discarded before the scribe ran. The `capture_gm_response_node` copied only call args (name + notation) into an intermediate `gm_tool_calls` state field, dropping the `ToolMessage` results (the actual roll total) entirely. The scribe never received any mechanical data and could only record pure narrative events with no roll outcomes.

This fix removes the `gm_tool_calls` intermediate field and has both the accountant and scribe init nodes read directly from `gm_messages`, which already contains the full tool loop (AIMessage tool calls + ToolMessage results). Two shared helpers in `utils.py` extract what each agent needs. The scribe now receives a `=== MECHANICS THIS TURN ===` block and is instructed to include roll notation, total, and reason inline in event descriptions.

## Root Cause

`capture_gm_response_node` extracted only `{name, args}` from `AIMessage.tool_calls` into `gm_tool_calls`. `ToolMessage` results were never read. The `gm_messages` state field already holds the complete tool loop but neither the accountant nor scribe init nodes read from it directly — they relied on pre-extracted copies that were incomplete by design.

## Changes

- `src/agent/nodes/utils.py` — add `extract_gm_tool_calls(messages)` and `extract_gm_roll_results(messages)` helpers; the latter pairs each `roll_dice` AIMessage call to its `ToolMessage` result by `tool_call_id` and parses the JSON result
- `src/agent/nodes/gm.py` — simplify `capture_gm_response_node` to extract only `gm_final_response` (still needed for early UI broadcast); remove `gm_tool_calls` logic entirely
- `src/agent/state.py` — remove `gm_tool_calls` field (no new fields added)
- `src/agent/nodes/accountant.py` — replace `state.get("gm_tool_calls")` with `extract_gm_tool_calls(state.get("gm_messages"))` — identical behaviour, now reads the source directly
- `src/agent/nodes/scribe.py` — call `extract_gm_roll_results(gm_messages)` and inject a `=== MECHANICS THIS TURN ===` block before the scribe's final HumanMessage prompt
- `src/agent/prompts.py` — add `## Mechanics Recording` section to `SCRIBE_SYSTEM_PROMPT` instructing the scribe to include roll data inline in event `description` fields

## How to Test

1. Start a game session and have a player declare a skill check (e.g. "I do a perception check").
2. The GM rolls `roll_dice` (e.g. `1d20+3`).
3. After the turn completes, open the events log.
4. Expected: the event description for that turn includes the roll inline, e.g. `[Roll: 1d20+3 = 6 (Rolled [3] +3 = 6) — Perception check]`.
5. Verify the accountant still correctly identifies `roll_dice` as a tool the GM already called (no regression in the "TOOLS GM ALREADY CALLED" block).

## Linked Issue

Closes #26

## Linked Bug Reports

- `bug_reports._id=699e65fa22b2cf40a970c818`
- `triages._id=699f16626e67483523e87db2`